### PR TITLE
Standalone Docker-Compose and Running Instructions

### DIFF
--- a/docs/using-image-manager.md
+++ b/docs/using-image-manager.md
@@ -1,8 +1,24 @@
 # Using ImageManager
 
-All examples in this page consider that all dojot's components are up and running (check [the documentation](http://dojotdocs.readthedocs.io/) for how to do that). All request will include a ```${JWT}``` variable - this was retrieved from [auth](https://github.com/dojot/auth) component.
+These instructions are meant for development only. 
+They should be run on the repository root and will execute the following:
+1. Run the necessary environment(postgres+minio) using docker-compose
+2. Build an image based on the current repository
+3. Run the application inside docker compose network
+4. Run the test application
 
-------------
+Obs.: Using the option  ```-v $PWD:/usr/src/app local/imagemanager```
+will link the docker image application with the local development code,
+any changes in the code will update the application immediately using flask's hot
+swap mechanism
 
-Since the upload process involves timeouts, testing it by hand may prove cumbersome.
-Check out test/client.py for programatic examples of the API
+On terminal #1:
+
+    docker-compose -f local/compose.yml -p imgm up -d
+    docker build -f Dockerfile -t local/imagemanager .
+    docker run --rm -it --network imgm_default -p 8000:5000 --network-alias image-manager -v $PWD:/usr/src/app local/imagemanager
+    
+On terminal #2:
+    
+    cd tests/
+    python3 client.py

--- a/local/compose.yml
+++ b/local/compose.yml
@@ -1,0 +1,24 @@
+version: '2.1'
+services:
+  
+  postgres:
+    image: "postgres:9.4"
+    restart: always
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: "minio/minio"
+    restart: always
+    volumes:
+      - /mnt/data:/data
+      - /mnt/config:/root/.minio
+    ports:
+      - "9001:9000"
+    environment:
+      MINIO_ACCESS_KEY: 9HEODSF6WQN5EZ39DM7Z
+      MINIO_SECRET_KEY: fT5nAgHR9pkj0yYsBdc4p+PPq6ArjshcPdz0HA6W
+    command: server /data

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,12 +1,22 @@
 import requests
 import json
 import urllib.parse
+import jwt
+import time
+import binascii
+import os
+import datetime
 
-# Get auth
-payload = {"username": "admin", "passwd": "admin"}
-url = 'http://localhost:8000/auth'
-r = requests.post(url, json=payload)
-jwt = json.loads(r.text)['jwt']
+ts = time.time()
+st = datetime.datetime.fromtimestamp(ts).strftime('%Y%m%d%H%M%S')
+
+service = 'test' + st + '_t'  # This ensures an isolated tenant each time this test suite is run
+encode_data = {'userid': 1, 'name': 'Admin (superuser)', 'groups': [1], 'iat': 1517339633, 'exp': 1517340053,
+               'email': 'admin@noemail.com', 'profile': 'admin', 'iss': 'eGfIBvOLxz5aQxA92lFk5OExZmBMZDDh',
+               'service': service, 'jti': '7e3086317df2c299cef280932da856e5', 'username': 'admin'}
+
+encoded = jwt.encode(encode_data, 'secret', algorithm='HS256')
+jwt_token = str(encoded, 'ascii')
 
 # Post metadata
 base_url = 'http://localhost:8000/image/'
@@ -16,7 +26,7 @@ payload = {
     "hw_version": "1.0.0-revA",
     "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94"
 }
-headers = {'Authorization': 'Bearer ' + jwt}
+headers = {'Authorization': 'Bearer ' + jwt_token}
 r = requests.post(base_url, json=payload, headers=headers)
 print(r.text)
 
@@ -27,7 +37,7 @@ url = urllib.parse.urljoin(base_url, binary_url)
 print(url)
 
 # Upload File
-headers = {'Authorization': 'Bearer ' + jwt}
+headers = {'Authorization': 'Bearer ' + jwt_token}
 files = {'image': open('example.hex', 'rb')}
 r = requests.post(url, files=files, headers=headers)
 print(r.text)


### PR DESCRIPTION
* Add a local docker-compose with necessary environment
* Use a mock auth key with a timestamped tenant to isolate each run in the DB
* Resolves #3 
