### PR TITLE
Remove SHA1 verification

### DIFF
--- a/ImageManager/DatabaseModels.py
+++ b/ImageManager/DatabaseModels.py
@@ -12,7 +12,6 @@ app.config['SQLALCHEMY_DATABASE_URI'] = CONFIG.get_db_url()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-
 minioClient = Minio(CONFIG.s3url, CONFIG.s3user, CONFIG.s3pass, secure=False)
 
 
@@ -25,7 +24,6 @@ class Image(db.Model):
     updated = db.Column(db.DateTime, onupdate=datetime.now)
 
     fw_version = db.Column(db.String(128), nullable=False)
-    sha1 = db.Column(db.String(40), nullable=False)
     confirmed = db.Column(db.Boolean, default=False, nullable=False)
 
     def __repr__(self):
@@ -41,6 +39,7 @@ def assert_image_exists(image_id):
 
 def get_all_images():
     return Image.query.all()
+
 
 def get_all_images_filter(label):
     try:

--- a/ImageManager/ImageManager.py
+++ b/ImageManager/ImageManager.py
@@ -41,6 +41,7 @@ def get_all():
         else:
             return format_response(e.error_code, e.message)
 
+
 @image.route('/image/binary/', methods=['GET'])
 def get_all_binaries():
     try:
@@ -53,7 +54,6 @@ def get_all_binaries():
             return make_response(jsonify(e.message), e.error_code)
         else:
             return format_response(e.error_code, e.message)
-
 
 
 @image.route('/image/<imageid>', methods=['GET'])
@@ -172,11 +172,6 @@ def upload_image(imageid):
 
         for f in file_data:
             print(f)
-
-        file_data.seek(0)
-        sha1 = calculate_sha1(file_data)
-        if sha1 != orm_image.sha1:
-            raise HTTPRequestError(400, "Corrupted image. Invalid SHA1")
 
         extension = file_data.filename.rsplit('.', 1)[1].lower()
         filename = imageid + '.' + extension

--- a/ImageManager/SerializationModels.py
+++ b/ImageManager/SerializationModels.py
@@ -17,7 +17,6 @@ class ImageSchema(Schema):
     updated = fields.DateTime(dump_only=True)
 
     fw_version = fields.String(required=True)
-    sha1 = fields.String(required=True)
     confirmed = fields.Bool(required=False)
 
     @post_dump

--- a/ImageManager/utils.py
+++ b/ImageManager/utils.py
@@ -47,17 +47,3 @@ def get_pagination(request):
 
     except TypeError:
         raise HTTPRequestError(400, "page_size and page_num must be integers")
-
-
-def calculate_sha1(filedesc):
-    # BUF_SIZE is totally arbitrary, change for your app!
-    BUF_SIZE = 65536  # lets read stuff in 64kb chunks!
-    sha1 = hashlib.sha1()
-    # Calculate sha1 for our example file
-    while True:
-        data = filedesc.read(BUF_SIZE)
-        if not data:
-            break
-        sha1.update(data)
-
-    return sha1.hexdigest()

--- a/docs/api.apib
+++ b/docs/api.apib
@@ -29,7 +29,6 @@ Simple CRUD service for storing firmware image metadata and binaries
                     "confirmed": true,
                     "label": "ExampleFW",
                     "fw_version": "1.0.0-rc1",
-                    "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94",
                     "id": "b60aa5e9-cbe6-4b51-b76c-08cf8273db07"
                   },
                   {
@@ -37,7 +36,6 @@ Simple CRUD service for storing firmware image metadata and binaries
                     "confirmed": false,
                     "label": "ExampleFW",
                     "fw_version": "1.0.0-rc1",
-                    "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94",
                     "id": "51b39543-9de1-4751-9fe2-48c8d6038ba1"
                   },
                   {
@@ -45,8 +43,7 @@ Simple CRUD service for storing firmware image metadata and binaries
                     "created": "2018-02-22T21:30:39.740576+00:00",
                     "fw_version": "1.0.0-rc1",
                     "id": "c929e347-0cd3-4925-a9ed-44ec59f7a1b9",
-                    "label": "ExampleFW",
-                    "sha1": "87acec17cd9dcd20a716cc2cf67417b71c8a0000"
+                    "label": "ExampleFW"
                   }
 
             ]
@@ -71,7 +68,6 @@ All fields are required, images with missing metadata fields will return an erro
 
 + label (string) - An informative human-readable label
 + fw_version (string) - FW Semantic versioning info
-+ sha1 (string) - Expected SHA1 of the image binary, used for consistency
 
 + Request (application/json)
     + Headers
@@ -81,8 +77,7 @@ All fields are required, images with missing metadata fields will return an erro
 
             {
                 "label": "FW_Example",
-                "fw_version": "1.0.0",
-                "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                "fw_version": "1.0.0"
             }
 
 
@@ -118,8 +113,7 @@ All fields are required, images with missing metadata fields will return an erro
     + Body
 
             {
-                "fw_version": "1.0.0",
-                "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                "fw_version": "1.0.0"
             }
 
 + Response 400 (application/json)
@@ -166,8 +160,7 @@ All fields are required, images with missing metadata fields will return an erro
 
            {
                 "label": "FW_Example",
-                "fw_version": "1.0.0",
-                "sha1": "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                "fw_version": "1.0.0"
             }
 
 
@@ -239,24 +232,4 @@ All fields are required, images with missing metadata fields will return an erro
                 "message": "No such image: 51b39543-9de1-4751-9fe2-1asdasdsss4",
                 "status": 404
             }
-
-### Posting an binary with wrong SHA1 [POST]
-
-+ Parameters
-    + image_id: `c929e347-0cd3-4925-a9ed-44ec59f7a1b9` (guid) - Unique ID
-
-+ Request (multipart/form-data;boundary=BOUNDARY)
-    [Image Binaries][]
-
-
-+ Response 400 (application/json)
-    + Body
-
-            {
-                "message": "Corrupted image. Invalid SHA1",
-                "status": 400
-            }
-
-=
-
 

--- a/tests/db_fixture.py
+++ b/tests/db_fixture.py
@@ -21,7 +21,6 @@ def run():
     payload = {
         "label": "ExampleFW",
         "fw_version": "1.0.0-rc1",
-        "sha1": "87acec17cd9dcd20a716cc2cf67417b71c8a7016",
         "confirmed": False
     }
 
@@ -43,11 +42,10 @@ def run():
     db.session.add(orm_image)
     db.session.commit()
 
-    # Store Third object with wrong SHA1
+    # Store Third object
     id = "c929e347-0cd3-4925-a9ed-44ec59f7a1b9"
     data = image_schema.load(payload)
     data['id'] = id
-    data['sha1'] = "87acec17cd9dcd20a716cc2cf67417b71c8a0000"
     orm_image = Image(**data)
     db.session.add(orm_image)
     db.session.commit()


### PR DESCRIPTION
So far sha1 verification has proven to be more a burden than a feature, it increases complexity and load of the front-end application with no real benefits.
Https ensures both security and reliability. The only real use case for sha1 verification is when the conection breaks mid-upload whereas a simple filesize field would suffice to avoid broken files.
This is a proposal to remove this feature, at least for now.